### PR TITLE
Remove GetArrisXXX - missing in new FW

### DIFF
--- a/retriever.go
+++ b/retriever.go
@@ -42,8 +42,6 @@ var statusSubCommands = []string{
 	// Just contains 'XXX' (Not useful).
 	"GetCustomerStatusXXX",
 	// Just contains 'XXX' (Not useful).
-	"GetArrisXXX",
-	// Just contains 'XXX' (Not useful).
 	"GetCustomerStatusLogXXX",
 }
 


### PR DESCRIPTION
This field is missing in my modem (which causes an error), likely due to a recent FW update:
```
"FirmwareVersion": "TB01.03.001.10_012022_212.S3",
"CustomerVersion": "Prod_19.2_d31",
```